### PR TITLE
Couple of fixes in latex output

### DIFF
--- a/gosh
+++ b/gosh
@@ -1295,7 +1295,7 @@ proc query_footnote {line token} {
 
 	# we search for the footnote with the minimum distance from the reference
 	set lowest_line_number 10000000
-	set result ""
+	set result -1
 
 	foreach idx [array names footnotes] {
 

--- a/gosh
+++ b/gosh
@@ -107,6 +107,8 @@ proc out_latex {string {line -1}} {
 	regsub -all {=>} $string "\$\\Rightarrow\$" string
 	regsub -all {<=} $string "\$\\Leftarrow\$" string
 
+	regsub -all {\\<} $string "\\textbackslash<" string
+	regsub -all {\\>} $string "\\textbackslash>" string
 	regsub -all {<} $string "\\mbox{\$<\$}" string
 	regsub -all {>} $string "\\mbox{\$>\$}" string
 


### PR DESCRIPTION
I stumbled upon two issues when building a print version of the platforms document. First, the document contains "\<" that is not replaced correctly (appreas at "mbox<"). Second, when building a document without footnotes gosh failed complaining about non-existent array entries.